### PR TITLE
TH - Integration

### DIFF
--- a/janus/app/Main.hs
+++ b/janus/app/Main.hs
@@ -35,5 +35,5 @@ main = run =<< execParser (parseOptions `withInfo` "Janus DSL")
 
 -- | Run.
 run :: Options -> IO ()
-run (Options inputFile dummyInt) = do
+run (Options inputFile dummyInt) =
   putStrLn ""

--- a/janus/app/Main.hs
+++ b/janus/app/Main.hs
@@ -3,11 +3,10 @@ module Main where
 import Options.Applicative
 import Data.Semigroup ((<>))
 
+import Parser.JanusParser
+
 -- | Command-line options.
-data Options = Options
-  { inputFile :: String
-  , intOpt    :: Int
-  }
+newtype Options = Options { inputFile :: String }
 
 -- | Parsing of command-line options.
 parseOptions :: Parser Options
@@ -18,22 +17,14 @@ parseOptions = Options
       <> metavar "STRING"
       <> help "Janus source file"
       )
-  <*> option auto
-      (  long "dummy-int"
-      <> showDefault
-      <> value 1
-      <> metavar "INT"
-      <> help "Dummy integer argument"
-      )
-
-withInfo :: Parser a -> String -> ParserInfo a
-withInfo opts desc = info (helper <*> opts) $ progDesc desc
 
 -- | Main.
 main :: IO ()
 main = run =<< execParser (parseOptions `withInfo` "Janus DSL")
-
--- | Run.
-run :: Options -> IO ()
-run (Options inputFile dummyInt) =
-  putStrLn ""
+  where
+    withInfo :: Parser a -> String -> ParserInfo a
+    withInfo opts desc = info (helper <*> opts) $ progDesc desc
+    run :: Options -> IO ()
+    run (Options inputFile) = do
+      prog <- readFile inputFile
+      print $ parser "" 0 0 prog

--- a/janus/examples/test1.janus
+++ b/janus/examples/test1.janus
@@ -1,6 +1,6 @@
 x :: Int;
 
-procedure f(x::Int, y::Int->String)
+procedure main(x::Int, y::Int->String)
 {
     x += 3;
     y ^= 1;

--- a/janus/janus.cabal
+++ b/janus/janus.cabal
@@ -43,6 +43,8 @@ test-suite janus-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   other-modules:       TQQ
+                     , TSemanticChecker
+                     , TParser
   build-depends:       base
                      , janus
                      , test-framework

--- a/janus/janus.cabal
+++ b/janus/janus.cabal
@@ -11,6 +11,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     AST
+                     , QQ
                      , StdLib.ArrayIndexer
                      , StdLib.DefaultValue
                      , StdLib.FieldIndexer
@@ -41,6 +42,7 @@ test-suite janus-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
+  other-modules:       TQQ
   build-depends:       base
                      , janus
                      , test-framework

--- a/janus/src/QQ.hs
+++ b/janus/src/QQ.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module QQ where
+
+import Control.Monad
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+
+import AST
+
+type Position = ( String -- filename
+                , Int    -- row
+                , Int    -- column
+                )
+
+runParserWithLoc :: Position -> String -> Program
+runParserWithLoc _ _ = Program [] -- TODO rebase onto #41
+
+semanticCheck :: Program -> Bool
+semanticCheck _ = True -- TODO rebase onto #43
+
+-- | Arith quasi-quoter.
+hanus :: QuasiQuoter
+hanus = QuasiQuoter {
+      quoteExp = undefined
+    , quotePat = undefined
+    , quoteType = undefined
+    , quoteDec  = \prog-> do
+        p <- runQQParser prog
+        exp <- [e| 10 |] -- Normal program
+        exp' <- [e| -10 |] -- Reverse program
+        return [decl "decl" exp, decl "decl'" exp']
+    }
+    where
+      decl name ex = FunD (mkName name) [Clause [] (NormalB ex) []]
+
+-- | Arith quasi-quoter for files.
+hanusF :: QuasiQuoter
+hanusF = quoteFile hanus
+
+-- | Parse program by passing location info and doing semantic checking.
+runQQParser :: String -> Q Program
+runQQParser prog = do
+  loc <- location
+  let pos = (loc_filename loc, fst (loc_start loc), snd (loc_start loc))
+  let p = runParserWithLoc pos prog
+  unless (semanticCheck p) $ fail "Semantic check failed!"
+  return p

--- a/janus/src/QQ.hs
+++ b/janus/src/QQ.hs
@@ -7,17 +7,8 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Quote
 
 import AST
-
-type Position = ( String -- filename
-                , Int    -- row
-                , Int    -- column
-                )
-
-runParserWithLoc :: Position -> String -> Program
-runParserWithLoc _ _ = Program [] -- TODO rebase onto #41
-
-semanticCheck :: Program -> Bool
-semanticCheck _ = True -- TODO rebase onto #43
+import Parser.JanusParser (parser)
+import SemanticChecker (semanticCheck)
 
 -- | Arith quasi-quoter.
 hanus :: QuasiQuoter
@@ -27,9 +18,9 @@ hanus = QuasiQuoter {
     , quoteType = undefined
     , quoteDec  = \prog-> do
         p <- runQQParser prog
-        exp <- [e| 10 |] -- Normal program
-        exp' <- [e| -10 |] -- Reverse program
-        return [decl "decl" exp, decl "decl'" exp']
+        exp <- [e| True |] -- TODO Normal program
+        exp' <- [e| False |] -- TODO Reverse program
+        return [decl "prog" exp, decl "coProg" exp']
     }
     where
       decl name ex = FunD (mkName name) [Clause [] (NormalB ex) []]
@@ -42,7 +33,7 @@ hanusF = quoteFile hanus
 runQQParser :: String -> Q Program
 runQQParser prog = do
   loc <- location
-  let pos = (loc_filename loc, fst (loc_start loc), snd (loc_start loc))
-  let p = runParserWithLoc pos prog
+  let (row, col) = loc_start loc
+  let p = parser (loc_filename loc) row col prog
   unless (semanticCheck p) $ fail "Semantic check failed!"
   return p

--- a/janus/src/SemanticChecker.hs
+++ b/janus/src/SemanticChecker.hs
@@ -1,8 +1,9 @@
 module SemanticChecker (extractVarsE, semanticCheck) where
 
-import AST
-import Data.List (nub, (\\))
-import Language.Haskell.TH.Syntax
+import           AST
+import           Data.List                  (nub, (\\))
+import           Language.Haskell.TH.Syntax
+
 
 semanticCheck :: Program -> Bool
 semanticCheck prog =
@@ -14,8 +15,8 @@ mainExists (Program decls) =
   any checkMain decls
   where
     checkMain :: Declaration -> Bool
-    checkMain (Procedure (Identifier "main") [] _) = True
-    checkMain _                                    = False
+    checkMain (Procedure (Identifier "main") _ _) = True
+    checkMain _                                   = False
 
 -- | Check that variables on the LHS does not appear on the RHS.
 rhsCheck :: Program -> Bool

--- a/janus/test/Spec.hs
+++ b/janus/test/Spec.hs
@@ -2,7 +2,7 @@
 
 import Test.Framework (defaultMain, testGroup)
 import Test.Framework.Providers.HUnit
-import Test.HUnit
+import Test.QQ
 
 import Data.List ((\\))
 import Language.Haskell.TH
@@ -19,6 +19,7 @@ main = defaultMain
   | (testName, testSuite) <- [ ("PRS", parserTests)
                              , ("VAR", varTests)
                              , ("SEM", semanticTests)
+                             , ("QQ", qqTests)
                              ]
   ]
 

--- a/janus/test/Spec.hs
+++ b/janus/test/Spec.hs
@@ -1,98 +1,18 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 import Test.Framework (defaultMain, testGroup)
 import Test.Framework.Providers.HUnit
-import Test.QQ
 
-import Data.List ((\\))
-import Language.Haskell.TH
-import System.IO.Unsafe (unsafePerformIO)
-
-import AST
-import Parser.JanusParser
-import SemanticChecker (extractVarsE, semanticCheck)
-
-import Debug.Trace
+import TParser
+import TQQ
+import TSemanticChecker
 
 main = defaultMain
   [ constructTestSuite testName testSuite
-  | (testName, testSuite) <- [ ("PRS", parserTests)
-                             , ("VAR", varTests)
-                             , ("SEM", semanticTests)
-                             , ("QQ", qqTests)
+  | (testName, testSuite) <- [ ("PARSER", parserTests)
+                             , ("VARIABLE_EXTRACTION", varTests)
+                             , ("SEMANTIC_CHECKING", semanticTests)
+                             , ("QUASI_QUOTATION", qqTests)
                              ]
   ]
 
 constructTestSuite s suite =
   testGroup s [testCase (s ++ "_" ++ show i) t | (i, t) <- zip [1..] suite]
-
-shouldParse x = parses x @?= True
-
-parserTests =
-  [ shouldParse "x :: Int; y :: Int;"
-  , shouldParse "x :: Int; procedure foo(y :: Int) { x += y * 42; }"
-  , shouldParse "procedure foo() { if x * 3 == 1 then y += 42; else swap x y; fi False; }"
-  , shouldParse "procedure foo() { local x :: Int = 42; x += 10; delocal 52; }"
-  -- Loop with `do` and `loop`.
-  , shouldParse "procedure foo() { from True do x += 1; loop x += 2; until x == 1000; }"
-  , shouldParse "procedure foo() { from x * 100 == 400 do x += 1; loop if True then x += 1; else complement x; fi True; until x == 1000; }"
-  -- Loop with `do`
-  , shouldParse "procedure foo() { from x * 100 == 400 do x += 1; until x == 1000; }"
-  -- Loop with `loop`.
-  , shouldParse "procedure foo() { from x * 100 == 400 do if True then x += 1; else complement x; fi True; until x == 1000; }"
-  , shouldParse "procedure foo() { call f x y; swap x y; complement x; }"
-  ]
-
-infix 1 @~>
-(@~>) e vars = eVars @?= vars
-  where eVars = extractVarsE (unsafePerformIO $ runQ e)
-
-data TestRec = TestRec { x :: Int, y :: Int -> Int }
-varTests =
-  [ [| x + y |] @~> ["x", "+", "y"]
-  , [| foo x y |] @~> ["foo", "x", "y"]
-  , [| \x -> x + (y + 1) |] @~> ["+", "y"]
-  , [| map (+ x) [y] |] @~> ["map", "+", "x", "y"]
-  , [| (x + x) + (1 + (y - 10)) |] @~> ["x", "+", "y", "-"]
-  , [| \(x, y) -> x * y |] @~> ["*"]
-  , [| if x then x + y else x + z |] @~> ["x", "+", "y", "z"]
-  , [| sum [x..(y + 1)] |] @~> ["sum", "x", "y", "+"]
-  , [| [x, \y -> y + 1] |] @~> ["x", "+"]
-  , [| \y -> x + y :: Int -> Int |] @~> ["x", "+"]
-  , [| TestRec { x = x, y = \y -> y + 5} |] @~> ["x", "+"]
-  , [| initialRec { y = \x -> x + y} |] @~> ["initialRec", "+", "y"]
-  ]
-
-semanticTests = [] {-
-  [ semanticCheck progT1 @?= True
-  , semanticCheck progT2 @?= True
-  , semanticCheck progT3 @?= True
-  , semanticCheck progF_noMain @?= False
-  , semanticCheck progF1 @?= False
-  , semanticCheck progF2 @?= False
-  , semanticCheck progF3 @?= False
-  , semanticCheck progF4 @?= False
-  ]
-  where progT1 = Program [ Procedure main [] [asgT] ]
-        progF1 = Program [ Procedure main [] [asgF1] ]
-        progF2 = Program [ Procedure main [] [asgF2] ]
-        progF3 = Program [ Procedure main [] [asgF3] ]
-        progF4 = Program []
-        progF_noMain = Program [ Procedure notMain [] [asgT] ]
-        progT2 = Program [ Procedure main [] [asgT2] ]
-        progT3 = Program [ Procedure notMain [] [asgT]
-                         , Procedure main [] [asgT] ]
-        [x, y, main, notMain] = map Identifier ["x", "y", "main", "notMain"]
-        [x', y'] = map (VarE . mkName) ["x", "y"]
-        int = ConT $ mkName "Int"
-        one = LitE $ IntegerL 1
-        plus = VarE '(+)
-        index arr = InfixE (Just arr) (VarE '(!!)) (Just one)
-        asgT = LHSIdentifier x .+= y'
-        asgF1 = LHSIdentifier x .+= x'
-        asgF2 =
-          LHSArray (LHSIdentifier x) one .+=
-          InfixE (Just $ index x') plus (Just one)
-        asgF3 = LHSArray (LHSIdentifier x) (index x') .+= one
-        asgT2 = LHSArray (LHSIdentifier x) (index y') .+= one
-        (.+=) e e' = Assignment "+=" [e] (Just e') -}

--- a/janus/test/TParser.hs
+++ b/janus/test/TParser.hs
@@ -1,0 +1,24 @@
+module TParser where
+
+import Test.Framework.Providers.HUnit
+import Test.HUnit
+
+import AST
+import Parser.JanusParser
+
+shouldParse x = parses x @?= True
+
+parserTests =
+  [ shouldParse "x :: Int; y :: Int;"
+  , shouldParse "x :: Int; procedure foo(y :: Int) { x += y * 42; }"
+  , shouldParse "procedure foo() { if x * 3 == 1 then y += 42; else swap x y; fi False; }"
+  , shouldParse "procedure foo() { local x :: Int = 42; x += 10; delocal 52; }"
+  -- Loop with `do` and `loop`.
+  , shouldParse "procedure foo() { from True do x += 1; loop x += 2; until x == 1000; }"
+  , shouldParse "procedure foo() { from x * 100 == 400 do x += 1; loop if True then x += 1; else complement x; fi True; until x == 1000; }"
+  -- Loop with `do`
+  , shouldParse "procedure foo() { from x * 100 == 400 do x += 1; until x == 1000; }"
+  -- Loop with `loop`.
+  , shouldParse "procedure foo() { from x * 100 == 400 do if True then x += 1; else complement x; fi True; until x == 1000; }"
+  , shouldParse "procedure foo() { call f x y; swap x y; complement x; }"
+  ]

--- a/janus/test/TQQ.hs
+++ b/janus/test/TQQ.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE QuasiQuotes #-}
-
 module TQQ where
 
 import Test.Framework.Providers.HUnit
@@ -7,17 +6,9 @@ import Test.HUnit
 
 import QQ
 
--- [janusF|examples/test.janus|]
-
-[hanus|
-x :: Int;
-procedure f(x::Int, y::Int->String) {
- x += 3;
- y ^= 1;
-}
-|]
+[hanusF|examples/test1.janus|]
 
 qqTests =
-  [ decl @?= 10
-  , decl' @?= -10
+  [ prog @?= True
+  , coProg @?= False
   ]

--- a/janus/test/TQQ.hs
+++ b/janus/test/TQQ.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module TQQ where
+
+import Test.Framework.Providers.HUnit
+import Test.HUnit
+
+import QQ
+
+-- [janusF|examples/test.janus|]
+
+[hanus|
+x :: Int;
+procedure f(x::Int, y::Int->String) {
+ x += 3;
+ y ^= 1;
+}
+|]
+
+qqTests =
+  [ decl @?= 10
+  , decl' @?= -10
+  ]

--- a/janus/test/TSemanticChecker.hs
+++ b/janus/test/TSemanticChecker.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE TemplateHaskell #-}
+module TSemanticChecker where
+
+import Test.Framework.Providers.HUnit
+import Test.HUnit
+
+import Language.Haskell.TH
+import System.IO.Unsafe (unsafePerformIO)
+
+import AST
+import SemanticChecker (extractVarsE, semanticCheck)
+
+
+infix 1 @~>
+(@~>) e vars = eVars @?= vars
+  where eVars = extractVarsE (unsafePerformIO $ runQ e)
+
+data TestRec = TestRec { x :: Int, y :: Int -> Int }
+varTests =
+  [ [| x + y |] @~> ["x", "+", "y"]
+  , [| foo x y |] @~> ["foo", "x", "y"]
+  , [| \x -> x + (y + 1) |] @~> ["+", "y"]
+  , [| map (+ x) [y] |] @~> ["map", "+", "x", "y"]
+  , [| (x + x) + (1 + (y - 10)) |] @~> ["x", "+", "y", "-"]
+  , [| \(x, y) -> x * y |] @~> ["*"]
+  , [| if x then x + y else x + z |] @~> ["x", "+", "y", "z"]
+  , [| sum [x..(y + 1)] |] @~> ["sum", "x", "y", "+"]
+  , [| [x, \y -> y + 1] |] @~> ["x", "+"]
+  , [| \y -> x + y :: Int -> Int |] @~> ["x", "+"]
+  , [| TestRec { x = x, y = \y -> y + 5} |] @~> ["x", "+"]
+  , [| initialRec { y = \x -> x + y} |] @~> ["initialRec", "+", "y"]
+  ]
+
+semanticTests =
+  [ semanticCheck progT1 @?= True
+  , semanticCheck progT2 @?= True
+  , semanticCheck progT3 @?= True
+  , semanticCheck progF_noMain @?= False
+  , semanticCheck progF1 @?= False
+  , semanticCheck progF2 @?= False
+  , semanticCheck progF3 @?= False
+  , semanticCheck progF4 @?= False
+  ]
+  where progT1 = Program [ Procedure main [] [asgT] ]
+        progF1 = Program [ Procedure main [] [asgF1] ]
+        progF2 = Program [ Procedure main [] [asgF2] ]
+        progF3 = Program [ Procedure main [] [asgF3] ]
+        progF4 = Program []
+        progF_noMain = Program [ Procedure notMain [] [asgT] ]
+        progT2 = Program [ Procedure main [] [asgT2] ]
+        progT3 = Program [ Procedure notMain [] [asgT]
+                         , Procedure main [] [asgT] ]
+        [x, y, main, notMain] = map Identifier ["x", "y", "main", "notMain"]
+        [x', y'] = map (VarE . mkName) ["x", "y"]
+        int = ConT $ mkName "Int"
+        one = LitE $ IntegerL 1
+        plus = VarE '(+)
+        index arr = InfixE (Just arr) (VarE '(!!)) (Just one)
+        asgT = LHSIdentifier x .+= y'
+        asgF1 = LHSIdentifier x .+= x'
+        asgF2 =
+          LHSArray (LHSIdentifier x) one .+=
+          InfixE (Just $ index x') plus (Just one)
+        asgF3 = LHSArray (LHSIdentifier x) (index x') .+= one
+        asgT2 = LHSArray (LHSIdentifier x) (index y') .+= one
+        (.+=) e = Assignment "+=" [e]


### PR DESCRIPTION
**Depends on ~#41~, ~#43~**
**Closes #1**

**I've made some changes for the language to be more similar to our needs for Janus.**

* Basic language for arithmetic expressions with a single addition operation
* Allows quasi-quoting ~~expressions and patterns~~program declarations.
* Allows embedding Haskell code in place of numbers (i.e. _anti-quotation_)
* This should give you a clear guide on how to implement your AST/Parser, in order to be easily integrated with TH.

File descriptions:
* **Arith.AST:** Defines the simple AST for Arith
  * _Anti-quotation_ requires extending the AST with ~~_meta variables_~~_meta expressions_ , i.e. `MetaExpr String`
  * The `semanticChecker` will be called at compile-time!
* **Arith.Parser:** Parser for Arith
  * Notice how the source location information is propagated to the parser for meaningful error messages
  * Notice how Haskell code is parsed into the `Exp` datatype using the `haskell-src-meta` package.
* **Arith.QQ:** Quasi-quoter for Arith
  * `[arith|<program>]` for inline programs
  * `[arithF|<filename>]` for programs written in an external file
  * Notice the generation of **two** program declarations (normal + reverse).
* **test/TArith:** Test showcasing the aforementioned capabilities