### PR TITLE
Fix parser

### DIFF
--- a/janus/src/Parser/JanusParser.hs
+++ b/janus/src/Parser/JanusParser.hs
@@ -99,7 +99,7 @@ pProcedure = Procedure
             where pVariableList = ([] <$ pToken ")") <<|> pNonEmptyArgumentList
 
 pBlock :: Parser Block
-pBlock = pList_ng pStatement
+pBlock = pList pStatement
 
 pStatement :: Parser Statement
 pStatement


### PR DESCRIPTION
The bug was caused by rewriting `greedyChoice`, and by not parsing whitespace on some parts.